### PR TITLE
Stop the async status task when stopping the server

### DIFF
--- a/rosjava_actionlib/src/main/java/com/github/ekumen/rosjava_actionlib/ActionServer.java
+++ b/rosjava_actionlib/src/main/java/com/github/ekumen/rosjava_actionlib/ActionServer.java
@@ -145,6 +145,10 @@ public class ActionServer<T_ACTION_GOAL extends Message,
    * Stop publishing the action server topics.
    */
   private void unpublishServer() {
+    // Stop the task run by the Timer.
+    statusTick.cancel();
+    statusTick.purge();
+
     if (statusPublisher != null) {
       statusPublisher.shutdown(5, TimeUnit.SECONDS);
       statusPublisher = null;


### PR DESCRIPTION
This makes the ActionServer class be disposed correctly